### PR TITLE
Wine error in MSSQL image when starting in container with >15 char container hostname

### DIFF
--- a/sql2000/start.sh
+++ b/sql2000/start.sh
@@ -1,2 +1,8 @@
 cd /root
+
+ip=$(/sbin/ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
+hostname=$(hostname)
+short_hostname=${hostname:0:15}
+echo "${ip} ${short_hostname}" >> /etc/hosts
+
 /usr/bin/wine .wine/drive_c/Program\ Files/Microsoft\ SQL\ Server/80/Tools/Binn/sqlmangr.exe


### PR DESCRIPTION
I hit the following error whilst trying to push rsmoorthy/mssql image into Kubernetes:

```
err:eventlog:ReportEventW L"gethostbyname(TCP/IP) : Error 11001"
```

This is most likely caused by the fact that winetricks is running in WinXP mode, which means NetBIOS has a hostname max char length of 15 characters, and very kindly truncates your actual hostname for you when attempting to do anything with it in Windows world.

https://social.technet.microsoft.com/Forums/office/en-US/4fe7b148-a01f-498f-a88a-06aef3edd81e/what-is-the-maximum-length-of-a-computer-name-in-windows?forum=winservergen

I found this out by adding `WINEDEBUG=+winsock` as an env var in my docker container, and found, in my case, that it was trying to look up a shortened version of the longer hostname (legacy-jobs-85f6d69f85-5bm59):

```
trace:winsock:WS_gethostbyname "legacy-jobs-85f" ret 0
```

I then modified /root/start.sh to:

```
cd /root

ip=$(/sbin/ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
hostname=$(hostname)
short_hostname=${hostname:0:15}
echo "${ip} ${short_hostname}" >> /etc/hosts

/usr/bin/wine .wine/drive_c/Program\ Files/Microsoft\ SQL\ Server/80/Tools/Binn/sqlmangr.exe
```

and rebuilt the image. Now the port comes up no problem 👍 